### PR TITLE
Fix sorting by date in DC_Table

### DIFF
--- a/core-bundle/config/listeners.yml
+++ b/core-bundle/config/listeners.yml
@@ -20,6 +20,10 @@ services:
     arguments:
       [ '@database_connection' ]
 
+  Ferienpass\CoreBundle\EventListener\Callback\Table\Offer\DatesSortingListener:
+    tags: [ { name: contao.callback, table: Offer, target: config.onsubmit } ]
+    arguments: [ '@database_connection' ]
+
   Ferienpass\CoreBundle\EventListener\PrettyErrorScreenListener:
     arguments:
       - '%contao.pretty_error_screens%'

--- a/core-bundle/config/services.yml
+++ b/core-bundle/config/services.yml
@@ -197,6 +197,9 @@ services:
     tags:
       - { name: 'doctrine.event_listener', event: 'preUpdate' }
 
+  Ferienpass\CoreBundle\EventListener\Doctrine\Offer\DateSortingListener:
+    tags: [ { name: 'doctrine.event_listener', event: 'preUpdate' } ]
+
   Ferienpass\CoreBundle\EventListener\Doctrine\Offer\VariantListener:
     tags:
       - { name: 'doctrine.event_listener', event: 'preUpdate' }

--- a/core-bundle/src/Entity/Offer.php
+++ b/core-bundle/src/Entity/Offer.php
@@ -721,6 +721,11 @@ class Offer
         $this->saved = $saved;
     }
 
+    public function setDatesSorting(?int $datesSorting): void
+    {
+        $this->datesSorting = $datesSorting;
+    }
+
     public function getStatus(): string
     {
         if ($this->isCancelled()) {

--- a/core-bundle/src/EventListener/Callback/Table/Offer/DatesSortingListener.php
+++ b/core-bundle/src/EventListener/Callback/Table/Offer/DatesSortingListener.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Ferienpass package.
+ *
+ * (c) Richard Henkenjohann <richard@ferienpass.online>
+ *
+ * For more information visit the project website <https://ferienpass.online>
+ * or the documentation under <https://docs.ferienpass.online>.
+ */
+
+namespace Ferienpass\CoreBundle\EventListener\Callback\Table\Offer;
+
+use Contao\DataContainer;
+use Doctrine\DBAL\Connection;
+
+class DatesSortingListener
+{
+    private Connection $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function __invoke($dataContainer): void
+    {
+        if (!$dataContainer instanceof DataContainer) {
+            return;
+        }
+
+        $this->connection->executeQuery(<<<'SQL'
+UPDATE Offer O
+INNER JOIN OfferDate OD on O.id = OD.offer_id
+SET O.dates = UNIX_TIMESTAMP(OD.begin)
+WHERE OD.begin IS NOT NULL
+AND O.id = :id
+SQL
+            , ['id' => $dataContainer->activeRecord->id]);
+    }
+}

--- a/core-bundle/src/EventListener/Doctrine/Offer/DateSortingListener.php
+++ b/core-bundle/src/EventListener/Doctrine/Offer/DateSortingListener.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Ferienpass package.
+ *
+ * (c) Richard Henkenjohann <richard@ferienpass.online>
+ *
+ * For more information visit the project website <https://ferienpass.online>
+ * or the documentation under <https://docs.ferienpass.online>.
+ */
+
+namespace Ferienpass\CoreBundle\EventListener\Doctrine\Offer;
+
+use Doctrine\Persistence\Event\LifecycleEventArgs;
+use Ferienpass\CoreBundle\Entity\Offer;
+
+/**
+ * The field Offer.datesSorting is necessary for DC_Table to perform sorting on this field.
+ */
+class DateSortingListener
+{
+    public function preUpdate(LifecycleEventArgs $args): void
+    {
+        $entity = $args->getObject();
+        if (!$entity instanceof Offer) {
+            return;
+        }
+
+        $dates = $entity->getDates();
+        $date = $dates[0] ?? null;
+        if (null === $date || null === $date->getBegin()) {
+            return;
+        }
+
+        $entity->setDatesSorting($date->getBegin()->getTimestamp());
+    }
+}


### PR DESCRIPTION
Offer.dates is a one-to-many relation that DC_Table is unable to sort for. So this is a hack utilizing a dummy field.